### PR TITLE
feat: Implement UI enhancements - Pagination and Grid Layout

### DIFF
--- a/src/jikan_client.py
+++ b/src/jikan_client.py
@@ -52,22 +52,26 @@ def get_anime_details_by_id(mal_id: int) -> dict | None:
         print(f"Error fetching anime details for ID {mal_id}: {e}")
         return None
 
-def search_anime_by_genre(genre_id: int, page: int = 1, limit: int = 10) -> list:
+def search_anime_by_genre(genre_id: int, page: int = 1, limit: int = 10) -> tuple[list, dict | None]:
     """Searches for anime by genre ID using the Jikan API.
     Orders by score descending and filters for SFW (Safe For Work) content.
+    Returns a tuple containing the list of anime and pagination info.
     """
     url = f"{JIKAN_API_BASE_URL}/anime?genres={genre_id}&page={page}&limit={limit}&sfw=true&order_by=score&sort=desc"
     try:
         response = requests.get(url)
         time.sleep(0.5) # Respect basic rate limits
         if response.status_code == 200:
-            return response.json().get('data', [])
+            json_response = response.json()
+            anime_data = json_response.get('data', [])
+            pagination_info = json_response.get('pagination', None)
+            return anime_data, pagination_info
         else:
             print(f"Error searching anime by genre ID {genre_id}: Status code {response.status_code} - {response.text}")
-            return []
+            return [], None
     except requests.exceptions.RequestException as e:
         print(f"Error searching anime by genre ID {genre_id}: {e}")
-        return []
+        return [], None
 
 def get_anime_recommendations(mal_id: int) -> list:
     """Fetches anime recommendations for a given anime ID from the Jikan API."""

--- a/src/main.py
+++ b/src/main.py
@@ -12,12 +12,11 @@ from src.jikan_client import (
 def fetch_genre_map_from_api():
     """Fetches and caches the genre map from Jikan API."""
     print("Fetching genre map from Jikan API...")
-    # No st.error here, return None to handle it in main UI
     return get_genre_id_map()
 
 GENRE_ID_MAP = fetch_genre_map_from_api()
-if GENRE_ID_MAP is None: # Check if fetch failed
-    GENRE_ID_MAP = {} # Use empty map to prevent errors later, UI will show error message
+if GENRE_ID_MAP is None:
+    GENRE_ID_MAP = {}
 AVAILABLE_GENRES_FROM_API = sorted(GENRE_ID_MAP.keys())
 
 
@@ -28,12 +27,6 @@ def format_anime_data_from_jikan(jikan_anime_data):
     jpg_images = images.get('jpg', {}) if isinstance(images, dict) else {}
     image_url = jpg_images.get('large_image_url', jpg_images.get('image_url', None)) if isinstance(jpg_images, dict) else None
     genres_list = [g['name'] for g in jikan_anime_data.get('genres', []) if isinstance(g, dict) and 'name' in g]
-    # theme_names, studio_names, producer_names might be pre-populated by get_anime_details_by_id
-    # or need to be extracted if the raw Jikan object is passed.
-    # For now, format_anime_data_from_jikan will primarily rely on these being top-level keys
-    # if they were added by get_anime_details_by_id.
-    # If raw search results are passed, these might not be directly available in the same way.
-    # This function should consistently return these keys, defaulting to empty lists if not found.
 
     formatted_data = {
         'mal_id': jikan_anime_data.get('mal_id'),
@@ -49,16 +42,9 @@ def format_anime_data_from_jikan(jikan_anime_data):
     return formatted_data
 
 def recommend_similar_anime(favorite_anime_title: str, top_n: int = 5) -> list:
-    """
-    Hybrid recommendation:
-    Phase 1: Fetch direct Jikan recommendations.
-    Phase 2: If needed, augment with targeted keyword searches based on favorite's themes/studios.
-    Phase 3 (Next subtask): Score, merge, deduplicate, and rank all candidates.
-    """
     print(f"Hybrid Phase 1&2 for: {favorite_anime_title}")
-    st.session_state.jikan_error_displayed = False # Reset error flag
+    st.session_state.jikan_error_displayed = False
 
-    # --- Phase 1: Initial Jikan Recommendations & Favorite Anime Details ---
     with st.spinner(f"Searching for '{favorite_anime_title}'..."):
         searched_anime_list = search_anime_by_title(favorite_anime_title)
     if not searched_anime_list:
@@ -80,15 +66,11 @@ def recommend_similar_anime(favorite_anime_title: str, top_n: int = 5) -> list:
         st.session_state.jikan_error_displayed = True
         return []
 
-    # Ensure favorite_anime_details is also formatted for consistency, especially for genre_names
-    # Note: get_anime_details_by_id already adds theme_names, studio_names, producer_names.
-    # format_anime_data_from_jikan will ensure genres_list is also present.
     favorite_anime_formatted_details = format_anime_data_from_jikan(favorite_anime_details)
-    if not favorite_anime_formatted_details: # Should not happen if details were fetched
+    if not favorite_anime_formatted_details:
         st.error("Failed to format details for the favorite anime.")
         st.session_state.jikan_error_displayed = True
         return []
-
 
     with st.spinner(f"Fetching direct recommendations for '{favorite_anime_formatted_details['title']}'..."):
         direct_jikan_recs_raw = get_anime_recommendations(favorite_anime_mal_id)
@@ -100,21 +82,14 @@ def recommend_similar_anime(favorite_anime_title: str, top_n: int = 5) -> list:
             if formatted_rec and formatted_rec.get('mal_id') != favorite_anime_mal_id:
                 direct_jikan_recs_formatted.append(formatted_rec)
 
-    print(f"Found {len(direct_jikan_recs_formatted)} direct Jikan recommendations.")
-
-    # --- Phase 2: Augmentation via Targeted Search (Conditional & Simplified) ---
     augmented_recs_formatted = []
     if len(direct_jikan_recs_formatted) < top_n:
-        print("Direct recommendations less than top_n. Attempting augmentation...")
-
         fav_genres = favorite_anime_formatted_details.get('genres_list', [])
         fav_themes = favorite_anime_formatted_details.get('theme_names', [])
         fav_studios = favorite_anime_formatted_details.get('studio_names', [])
 
-        # Strategy 1: Top Theme + Top Genre
         if fav_themes and fav_genres:
             query1 = f"{fav_themes[0]} {fav_genres[0]}"
-            print(f"Augmentation query 1: {query1}")
             with st.spinner(f"Augmenting with search: '{query1}'..."):
                 results_q1_raw = search_anime_by_title(query1)
             if results_q1_raw:
@@ -123,10 +98,8 @@ def recommend_similar_anime(favorite_anime_title: str, top_n: int = 5) -> list:
                     if formatted_res and formatted_res.get('mal_id') != favorite_anime_mal_id:
                         augmented_recs_formatted.append(formatted_res)
 
-        # Strategy 2: Top Studio + Top Genre
-        if fav_studios and fav_genres and (len(direct_jikan_recs_formatted) + len(augmented_recs_formatted)) < top_n * 1.5 : # Avoid too many API calls if already close
+        if fav_studios and fav_genres and (len(direct_jikan_recs_formatted) + len(augmented_recs_formatted)) < top_n * 1.5 :
             query2 = f"{fav_studios[0]} {fav_genres[0]}"
-            print(f"Augmentation query 2: {query2}")
             with st.spinner(f"Augmenting with search: '{query2}'..."):
                 results_q2_raw = search_anime_by_title(query2)
             if results_q2_raw:
@@ -135,31 +108,21 @@ def recommend_similar_anime(favorite_anime_title: str, top_n: int = 5) -> list:
                     if formatted_res and formatted_res.get('mal_id') != favorite_anime_mal_id:
                         augmented_recs_formatted.append(formatted_res)
 
-        print(f"Found {len(augmented_recs_formatted)} potential augmented recommendations.")
-
-    # --- Phase 3: Combine, Score, and Rank ---
-
-    # Add is_direct_jikan_rec flag and initialize local_score
     for rec in direct_jikan_recs_formatted:
         rec['is_direct_jikan_rec'] = True
         rec['local_score'] = 0
     for rec in augmented_recs_formatted:
-        rec['is_direct_jikan_rec'] = False # Came from augmented search
+        rec['is_direct_jikan_rec'] = False
         rec['local_score'] = 0
 
-    # Combine and Deduplicate
-    all_candidates = {} # Use dict for deduplication based on mal_id
+    all_candidates = {}
     for rec in direct_jikan_recs_formatted + augmented_recs_formatted:
-        if rec.get('mal_id') and rec.get('mal_id') != favorite_anime_mal_id: # Exclude favorite itself
-            # If duplicate, direct Jikan rec takes precedence if it was already there
-            # or if the current one is direct and the existing one in all_candidates isn't.
+        if rec.get('mal_id') and rec.get('mal_id') != favorite_anime_mal_id:
             if rec['mal_id'] not in all_candidates or \
                (rec['is_direct_jikan_rec'] and not all_candidates[rec['mal_id']]['is_direct_jikan_rec']):
                 all_candidates[rec['mal_id']] = rec
 
     unique_candidates = list(all_candidates.values())
-
-    # Calculate local_score for all unique candidates
     fav_genres_set = set(g.lower() for g in favorite_anime_formatted_details.get('genres_list', []))
     fav_themes_set = set(t.lower() for t in favorite_anime_formatted_details.get('theme_names', []))
     fav_studios_set = set(s.lower() for s in favorite_anime_formatted_details.get('studio_names', []))
@@ -168,70 +131,68 @@ def recommend_similar_anime(favorite_anime_title: str, top_n: int = 5) -> list:
         candidate_genres_set = set(g.lower() for g in candidate.get('genres_list', []))
         candidate_themes_set = set(t.lower() for t in candidate.get('theme_names', []))
         candidate_studios_set = set(s.lower() for s in candidate.get('studio_names', []))
-
         score = 0
         score += len(fav_genres_set.intersection(candidate_genres_set)) * 2
         score += len(fav_themes_set.intersection(candidate_themes_set)) * 1
         score += len(fav_studios_set.intersection(candidate_studios_set)) * 3
         candidate['local_score'] = score
 
-    # Sort unique candidates: Direct Jikan recs first, then by Jikan score, then by local_score
     unique_candidates.sort(key=lambda x: (
         x.get('is_direct_jikan_rec', False),
-        x.get('score') or 0,  # Jikan's original score
+        x.get('score') or 0,
         x.get('local_score', 0)
-    ), reverse=True) # True for direct recs, higher scores = better
+    ), reverse=True)
 
     final_recommendations = unique_candidates[:top_n]
 
     if not final_recommendations and not st.session_state.jikan_error_displayed:
         st.info(f"No recommendations could be compiled for '{favorite_anime_title}' after filtering and scoring.")
         st.session_state.jikan_error_displayed = True
-
-    # Phase 4: Formatting - is largely handled by format_anime_data_from_jikan
-    # and the structure built. Ensure all needed fields are present.
-    # The fields 'is_direct_jikan_rec' and 'local_score' can remain for debugging or future UI enhancements.
-
     return final_recommendations
 
-
-def recommend_by_genre(genre_name: str, genre_id_map: dict, n: int = 3) -> list:
-    genre_id = genre_id_map.get(genre_name.lower())
-    if not genre_id:
-        st.error(f"Genre ID for '{genre_name}' not found. Cannot fetch recommendations.")
-        st.session_state.jikan_error_displayed = True
-        return []
-
-    anime_list_from_jikan = search_anime_by_genre(genre_id, limit=n * 2 + 5) # Fetch more to ensure we get N unique ones
-
-    seen_mal_ids = set()
-    formatted_recommendations = []
-    if anime_list_from_jikan:
-        for anime_data in anime_list_from_jikan:
-            formatted_rec = format_anime_data_from_jikan(anime_data)
-            if formatted_rec and formatted_rec.get('mal_id') not in seen_mal_ids:
-                formatted_recommendations.append(formatted_rec)
-                seen_mal_ids.add(formatted_rec['mal_id'])
-                if len(formatted_recommendations) >= n:
-                    break
-
-    if not formatted_recommendations:
-        st.info(f"No anime found for genre '{genre_name}' on MyAnimeList currently.")
-        st.session_state.jikan_error_displayed = True
-        return []
-
-    return formatted_recommendations # Already limited to N by the loop logic
-
 # --- Streamlit UI ---
+st.set_page_config(layout="wide") # Use wide layout for better grid display
 st.title('Anime Recommendation System')
 st.write('Welcome to the Anime Recommendation System! Discover anime based on your favorites or explore genres if you\'re new!')
 
+# Initialize session state variables
 if 'genre_recommendations' not in st.session_state:
     st.session_state.genre_recommendations = None
 if 'selected_genre' not in st.session_state:
     st.session_state.selected_genre = None
 if 'jikan_error_displayed' not in st.session_state:
     st.session_state.jikan_error_displayed = False
+if 'genre_page' not in st.session_state:
+    st.session_state.genre_page = 1
+if 'genre_last_page' not in st.session_state:
+    st.session_state.genre_last_page = 1
+if 'genre_has_next_page' not in st.session_state:
+    st.session_state.genre_has_next_page = False
+
+# --- Helper function for displaying an anime item in a column ---
+def display_anime_card(anime_rec, col):
+    with col:
+        with st.expander(f"{anime_rec['title']} (Score: {anime_rec.get('score', 'N/A')})", expanded=True):
+            if anime_rec.get('image_url') and isinstance(anime_rec.get('image_url'), str) and anime_rec.get('image_url').strip():
+                st.image(anime_rec['image_url'], use_column_width='auto')
+            else:
+                st.caption("No image available")
+
+            genres_str = ", ".join(anime_rec.get('genres_list', []))
+            if genres_str: st.markdown(f"**Genres:** {genres_str}")
+
+            themes_str = ", ".join(anime_rec.get('theme_names', []))
+            if themes_str: st.markdown(f"**Themes:** {themes_str}")
+
+            studios_str = ", ".join(anime_rec.get('studio_names', []))
+            if studios_str: st.markdown(f"**Studios:** {studios_str}")
+
+            synopsis = anime_rec.get('synopsis', 'N/A')
+            if synopsis and synopsis != 'No synopsis available.':
+                 st.caption(f"**Synopsis:** {synopsis[:150] + '...' if len(synopsis) > 150 else synopsis}")
+
+            if anime_rec.get('mal_id'):
+                st.markdown(f"[View on MyAnimeList](https://myanimelist.net/anime/{anime_rec['mal_id']})", unsafe_allow_html=True)
 
 
 st.header('Recommend Based on Your Favorite Anime')
@@ -244,28 +205,15 @@ if st.button('Recommend Similar Anime', key='recommend_similar_btn'):
 
     if anime_name_input:
         with st.spinner(f"Fetching recommendations similar to '{anime_name_input}'..."):
-            recommendations = recommend_similar_anime(anime_name_input, top_n=5)
+            recommendations = recommend_similar_anime(anime_name_input, top_n=6) # Fetch 6 for 2 rows of 3
 
         if recommendations:
             st.subheader(f"Recommendations similar to '{anime_name_input}':")
-            for i, rec in enumerate(recommendations):
-                with st.expander(f"{i+1}. {rec['title']} (Score: {rec.get('score', 'N/A')})"):
-                    if rec.get('image_url') and isinstance(rec.get('image_url'), str) and rec.get('image_url').strip():
-                        st.image(rec['image_url'], width=150)
-                    else:
-                        st.caption("No image available")
-                    st.write(f"**Genres:** {', '.join(rec.get('genres_list', ['N/A']))}")
-                    if rec.get('theme_names'):
-                        st.markdown(f"**Themes:** {', '.join(rec['theme_names'])}")
-                    if rec.get('studio_names'):
-                        st.markdown(f"**Studios:** {', '.join(rec['studio_names'])}")
-                    # Producers can be added similarly if desired:
-                    # if rec.get('producer_names'):
-                    #    st.markdown(f"**Producers:** {', '.join(rec['producer_names'])}")
-                    synopsis = rec.get('synopsis', 'N/A')
-                    st.caption(f"**Synopsis:** {synopsis[:250] + '...' if synopsis and len(synopsis) > 250 else synopsis}")
-                    if rec.get('mal_id'):
-                        st.markdown(f"[View on MyAnimeList](https://myanimelist.net/anime/{rec['mal_id']})")
+            num_columns = 3
+            for i in range(0, len(recommendations), num_columns):
+                cols = st.columns(num_columns)
+                for j, rec in enumerate(recommendations[i : i + num_columns]):
+                    display_anime_card(rec, cols[j])
         elif not st.session_state.jikan_error_displayed:
             st.info(f"No recommendations found for '{anime_name_input}'.")
     else:
@@ -283,40 +231,81 @@ else:
     if not actual_genres_to_show:
         st.info("Could not identify common genres from the loaded Jikan genre list to display as buttons.")
     else:
-        cols = st.columns(3)
-        current_col = 0
+        # --- Genre Button Selection ---
+        button_cols = st.columns(6) # More columns for genre buttons
+        col_idx = 0
         for genre_display_name in actual_genres_to_show:
-            button_label = f"Show {genre_display_name}"
+            button_label = f"{genre_display_name}" # Shorter labels
             genre_key_name = genre_display_name.replace(" ", "_").replace("-", "_").lower()
-            if cols[current_col].button(button_label, key=f"genre_btn_{genre_key_name}"):
-                st.session_state.selected_genre = genre_display_name
+            if button_cols[col_idx % 6].button(button_label, key=f"genre_btn_{genre_key_name}"):
+                if st.session_state.selected_genre != genre_display_name:
+                    st.session_state.selected_genre = genre_display_name
+                    st.session_state.genre_page = 1
+                    st.session_state.genre_recommendations = None
                 st.session_state.jikan_error_displayed = False
-                with st.spinner(f"Fetching recommendations for '{genre_display_name}'..."):
-                    recommendations = recommend_by_genre(genre_display_name, GENRE_ID_MAP, n=3)
+                st.experimental_rerun()
+            col_idx +=1
 
-                if recommendations:
-                    st.session_state.genre_recommendations = recommendations
-                else:
-                    st.session_state.genre_recommendations = []
-            current_col = (current_col + 1) % 3
+    # --- Data Fetching and Display for Selected Genre ---
+    if st.session_state.selected_genre:
+        st.subheader(f"Exploring {st.session_state.selected_genre} Anime (Page {st.session_state.genre_page})")
+        genre_id = GENRE_ID_MAP.get(st.session_state.selected_genre.lower())
 
-        if st.session_state.selected_genre and st.session_state.genre_recommendations is not None:
-            st.subheader(f"Top 3 {st.session_state.selected_genre} Anime Recommendations (from Jikan API):")
-            if st.session_state.genre_recommendations:
-                for i, rec in enumerate(st.session_state.genre_recommendations):
-                    with st.expander(f"{i+1}. {rec['title']} (Score: {rec.get('score', 'N/A')})"):
-                        if rec.get('image_url') and isinstance(rec.get('image_url'), str) and rec.get('image_url').strip():
-                            st.image(rec['image_url'], width=150)
-                        else:
-                            st.caption("No image available")
-                        st.write(f"**Genres:** {', '.join(rec.get('genres_list', ['N/A']))}")
-                        synopsis = rec.get('synopsis', 'N/A')
-                        st.caption(f"**Synopsis:** {synopsis[:250] + '...' if synopsis and len(synopsis) > 250 else synopsis}")
-                        if rec.get('mal_id'):
-                             st.markdown(f"[View on MyAnimeList](https://myanimelist.net/anime/{rec['mal_id']})")
-            elif not st.session_state.jikan_error_displayed:
-                 st.info(f"No recommendations found for {st.session_state.selected_genre} via Jikan API at the moment.")
+        if not genre_id:
+            st.error(f"Cannot find ID for genre '{st.session_state.selected_genre}'.")
+            st.session_state.jikan_error_displayed = True
+        else:
+            items_per_page = 9
+            with st.spinner(f"Fetching {st.session_state.selected_genre} anime (Page {st.session_state.genre_page})..."):
+                anime_list_raw, pagination_info = search_anime_by_genre(
+                    genre_id,
+                    page=st.session_state.genre_page,
+                    limit=items_per_page
+                )
 
+            if pagination_info:
+                st.session_state.genre_last_page = pagination_info.get('last_visible_page', st.session_state.genre_page)
+                st.session_state.genre_has_next_page = pagination_info.get('has_next_page', False)
+            else:
+                st.session_state.genre_last_page = st.session_state.genre_page
+                st.session_state.genre_has_next_page = False
+
+            formatted_recommendations = []
+            if anime_list_raw:
+                for anime_data in anime_list_raw:
+                    formatted = format_anime_data_from_jikan(anime_data)
+                    if formatted:
+                        formatted_recommendations.append(formatted)
+            st.session_state.genre_recommendations = formatted_recommendations
+
+            if not st.session_state.genre_recommendations and not st.session_state.jikan_error_displayed:
+                st.info(f"No anime found for {st.session_state.selected_genre} on this page.")
+
+    # --- Display Fetched Genre Recommendations in a Grid ---
+    if st.session_state.selected_genre and st.session_state.genre_recommendations:
+        num_columns_genre = 3
+        for i in range(0, len(st.session_state.genre_recommendations), num_columns_genre):
+            cols_genre = st.columns(num_columns_genre)
+            for j, rec in enumerate(st.session_state.genre_recommendations[i : i + num_columns_genre]):
+                 display_anime_card(rec, cols_genre[j])
+
+    # --- Pagination Controls ---
+    if st.session_state.selected_genre:
+        pg_col1, pg_col2, pg_col3 = st.columns([2, 3, 2]) # Adjusted column ratios
+        with pg_col1:
+            if st.button("⬅️ Previous Page", disabled=(st.session_state.genre_page <= 1), use_container_width=True):
+                st.session_state.genre_page -= 1
+                st.experimental_rerun()
+        with pg_col2:
+            if st.session_state.genre_last_page > 0 :
+                 st.markdown(f"<p style='text-align: center; font-weight: bold;'>Page {st.session_state.genre_page} of {st.session_state.genre_last_page}</p>", unsafe_allow_html=True)
+            else:
+                 st.markdown(f"<p style='text-align: center; font-weight: bold;'>Page {st.session_state.genre_page}</p>", unsafe_allow_html=True)
+
+        with pg_col3:
+            if st.button("Next Page ➡️", disabled=(not st.session_state.genre_has_next_page or st.session_state.genre_page >= st.session_state.genre_last_page), use_container_width=True):
+                st.session_state.genre_page += 1
+                st.experimental_rerun()
 
 with st.sidebar:
     st.title('Anime Recommendation System🤖')


### PR DESCRIPTION
This commit introduces significant UI improvements to the application:

1.  **Pagination for Genre Recommendations:**
    *   `jikan_client.search_anime_by_genre` now returns pagination data from the Jikan API.
    *   The "Explore by Genre" section in `main.py` implements pagination:
        *   Uses `st.session_state` to manage the current page for the selected genre.
        *   Displays "Previous," "Next," and "Page X of Y" controls.
        *   Buttons are enabled/disabled appropriately based on page boundaries.
        *   Fetches and displays 9 anime per page for the selected genre.

2.  **Grid Layout for Recommendations:**
    *   The page layout is set to `wide` via `st.set_page_config()` for better use of space.
    *   Both "Recommend Similar Anime" and "Explore by Genre" sections now display recommendations in a 3-column grid.
    *   A reusable helper function, `display_anime_card(anime_rec, col)`, has been created to render each anime card within an `st.expander`. This card includes the title, score, image, genres, themes, studios, a shortened synopsis, and a MAL link.

3.  **Minor Visual Polish:**
    *   The number of columns for genre selection buttons increased for compactness.
    *   Pagination buttons use `use_container_width=True` for better alignment.

These changes make the UI more organized, visually appealing, and user-friendly, especially when browsing through multiple anime in genre results.